### PR TITLE
38 integrate jwt checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: ci 
+on:
+  push:
+    branches:
+      - master 
+      - main
+      - dev
+permissions:
+  contents: write
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure Git Credentials
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV 
+      - uses: actions/cache@v4
+        with:
+          key: mkdocs-material-${{ env.cache_id }}
+          path: ~/.cache 
+          restore-keys: |
+            mkdocs-material-
+      - run: pip install mkdocs-material 
+      - run: mkdocs gh-deploy --force

--- a/backend/.env.test
+++ b/backend/.env.test
@@ -1,3 +1,3 @@
 # additional Config for LOCAL Test environment (bypass Cognito Auth)
 NODE_ENV=test
-AUTH_BYPASS=1
+AUTH_BYPASS=true

--- a/backend/.env.test
+++ b/backend/.env.test
@@ -1,0 +1,3 @@
+# additional Config for LOCAL Test environment (bypass Cognito Auth)
+NODE_ENV=test
+AUTH_BYPASS=1

--- a/backend/README.md
+++ b/backend/README.md
@@ -33,13 +33,13 @@ This directory contains the backend service for CloudSheets, built with Node.js,
     Starts the server in watch mode using `tsx`, automatically restarting on code changes.
 
 - **Test:**
+    Run server + tests together (single command)
     ```bash
-    # Run server + tests together (single command)
     npm run test:all`
-
-    # Alternatively, run tests against an already running server
     npm test
     ```
+    Alternatively, run tests against an already running server
+
     `npm run test:all` starts the local server with test environment overrides (`.env.local`) to bypass Cognito Auth, waits for port `8080` to be ready, and runs Vitest in watch mode.
 
 - **Migrations:**

--- a/backend/README.md
+++ b/backend/README.md
@@ -34,8 +34,13 @@ This directory contains the backend service for CloudSheets, built with Node.js,
 
 - **Test:**
     ```bash
+    # Run server + tests together (single command)
+    npm run test:all`
+
+    # Alternatively, run tests against an already running server
     npm test
     ```
+    `npm run test:all` starts the local server with test environment overrides (`.env.local`) to bypass Cognito Auth, waits for port `8080` to be ready, and runs Vitest in watch mode.
 
 - **Migrations:**
     - `npm run migrate:make` — Create a new migration file.

--- a/backend/knexfile.ts
+++ b/backend/knexfile.ts
@@ -12,7 +12,7 @@ export default {
   development: {
     client: 'pg',
     connection: {
-      connectionString: process.env.DATABASE_URL,
+      connectionString: process.env.DATABASE_URL, //hardcoded default (local)
     },
     pool: {
       min: 2,
@@ -29,7 +29,7 @@ export default {
   production: {
     client: 'pg',
     connection: {
-      connectionString: process.env.DATABASE_URL,
+      connectionString: process.env.DATABASE_URL, //injected from CDK in runtime
       ssl: process.env.DB_SSL === 'true' ? { rejectUnauthorized: false} : false, //activate SSL
     },
     pool: {

--- a/backend/knexfile.ts
+++ b/backend/knexfile.ts
@@ -30,6 +30,7 @@ export default {
     client: 'pg',
     connection: {
       connectionString: process.env.DATABASE_URL,
+      ssl: process.env.DB_SSL === 'true' ? { rejectUnauthorized: false} : false, //activate SSL
     },
     pool: {
       min: 2,
@@ -39,8 +40,8 @@ export default {
       directory: __dirname + '/migrations',
       tableName: 'knex_migrations',
     },
-    seeds: {
-      directory: __dirname + '/seeds/development',
-    },
+    // seeds: {
+    //   directory: __dirname + '/seeds/production',
+    // },
   },
 }

--- a/backend/migrations/20260526145507_001_init.sql.ts
+++ b/backend/migrations/20260526145507_001_init.sql.ts
@@ -4,7 +4,7 @@ import type { Knex } from "knex";
 export async function up(knex: Knex): Promise<void> {
   // Users table
   await knex.schema.createTable('users', table => {
-    table.string('id').primary(); // matching Cognito ID
+    table.string('id').primary(); // matching Cognito ID/Sub
     table.string('email').notNullable().unique();
     table.timestamp('created_at').defaultTo(knex.fn.now());
   });

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -14,6 +14,7 @@
         "@fastify/swagger": "^9.7.0",
         "@fastify/swagger-ui": "^5.2.6",
         "@fastify/websocket": "^11.2.0",
+        "aws-jwt-verify": "^5.2.1",
         "dotenv": "^17.4.2",
         "fastify": "^5.8.4",
         "fastify-websocket": "^4.2.2",
@@ -2258,6 +2259,15 @@
       "dependencies": {
         "@fastify/error": "^4.0.0",
         "fastq": "^1.17.1"
+      }
+    },
+    "node_modules/aws-jwt-verify": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/aws-jwt-verify/-/aws-jwt-verify-5.2.1.tgz",
+      "integrity": "sha512-J+buA4M+qvQDk58WXFBLkDodkEX3DDL1ac5XFQPW3opxAsaLXYu5hYnlSHsaBRDBUXBAn695kE/cw/mdyJKwJg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/balanced-match": {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -28,6 +28,8 @@
         "@types/supertest": "^7.2.0",
         "@typescript-eslint/eslint-plugin": "^8.58.0",
         "@typescript-eslint/parser": "^8.58.0",
+        "concurrently": "^10.0.3",
+        "dotenv-cli": "^11.0.0",
         "eslint": "^10.2.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.5",
@@ -38,6 +40,7 @@
         "tsx": "^4.21.0",
         "typescript": "^6.0.2",
         "vitest": "^4.1.7",
+        "wait-port": "^1.1.0",
         "yjs": "^13.6.30"
       }
     },
@@ -2175,6 +2178,19 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -2443,6 +2459,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2499,6 +2530,57 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/concurrently": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-10.0.3.tgz",
+      "integrity": "sha512-hc3LH4UaKWd/bbyDK/IGVa4RB6PtQ3CUYwtrkzqHn+wIG3Hr5fhpRlk0L/gCa8ZE1L/Ufj50Zho69cI5w8SQBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "rxjs": "7.8.2",
+        "shell-quote": "1.8.4",
+        "supports-color": "10.2.2",
+        "tree-kill": "1.2.2",
+        "yargs": "18.0.0"
+      },
+      "bin": {
+        "conc": "dist/bin/index.js",
+        "concurrently": "dist/bin/index.js"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/content-disposition": {
@@ -2722,6 +2804,51 @@
         "url": "https://dotenvx.com"
       }
     },
+    "node_modules/dotenv-cli": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-cli/-/dotenv-cli-11.0.0.tgz",
+      "integrity": "sha512-r5pA8idbk7GFWuHEU7trSTflWcdBpQEK+Aw17UrSHjS6CReuhrrPcyC3zcQBPQvhArRHnBo/h6eLH1fkCvNlww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "dotenv": "^17.1.0",
+        "dotenv-expand": "^12.0.0",
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "dotenv": "cli.js"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-12.0.3.tgz",
+      "integrity": "sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dotenv": "^16.4.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-expand/node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -2748,6 +2875,13 @@
         "readable-stream": "^3.1.1",
         "stream-shift": "^1.0.2"
       }
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
@@ -3545,6 +3679,29 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-intrinsic": {
@@ -5466,6 +5623,16 @@
         "@rolldown/binding-win32-x64-msvc": "1.1.3"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -5578,6 +5745,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/side-channel": {
@@ -5837,6 +6017,40 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -6087,6 +6301,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
       }
     },
     "node_modules/ts-api-utils": {
@@ -6473,6 +6697,34 @@
         }
       }
     },
+    "node_modules/wait-port": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/wait-port/-/wait-port-1.1.0.tgz",
+      "integrity": "sha512-3e04qkoN3LxTMLakdqeWth8nih8usyg+sf1Bgdf9wwUkp05iuK1eSY/QpLvscT/+F/gA89+LpUmmgBtesbqI2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "commander": "^9.3.0",
+        "debug": "^4.3.4"
+      },
+      "bin": {
+        "wait-port": "bin/wait-port.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/wait-port/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -6514,6 +6766,37 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/wrappy": {
@@ -6574,6 +6857,16 @@
         "yjs": "^13.0.0"
       }
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
@@ -6597,6 +6890,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/yjs": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,11 +5,13 @@
   "type": "module",
   "main": "index.ts",
   "scripts": {
-    "test": "vitest",
+    "test": "dotenv -e .env.test -- vitest",
     "test:ci": "vitest run",
+    "test:all": "concurrently -k -s first \"npm run dev:test\" \"wait-port 8080 && npm test\"",
     "build": "tsc -p tsconfig.json",
     "start": "node dist/index.js",
     "dev": "tsx watch src/index.ts",
+    "dev:test": "dotenv -e .env.test -- tsx watch src/index.ts",
     "migrate:make": "knex migrate:make",
     "migrate:latest": "knex migrate:latest",
     "migrate:rollback": "knex migrate:rollback",
@@ -40,6 +42,8 @@
     "@types/supertest": "^7.2.0",
     "@typescript-eslint/eslint-plugin": "^8.58.0",
     "@typescript-eslint/parser": "^8.58.0",
+    "concurrently": "^10.0.3",
+    "dotenv-cli": "^11.0.0",
     "eslint": "^10.2.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.5",
@@ -50,6 +54,7 @@
     "tsx": "^4.21.0",
     "typescript": "^6.0.2",
     "vitest": "^4.1.7",
+    "wait-port": "^1.1.0",
     "yjs": "^13.6.30"
   }
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,4 +1,3 @@
-
 {
   "name": "CloudSheets",
   "version": "1.0.0",
@@ -27,6 +26,7 @@
     "@fastify/swagger": "^9.7.0",
     "@fastify/swagger-ui": "^5.2.6",
     "@fastify/websocket": "^11.2.0",
+    "aws-jwt-verify": "^5.2.1",
     "dotenv": "^17.4.2",
     "fastify": "^5.8.4",
     "fastify-websocket": "^4.2.2",

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -4,6 +4,7 @@ import sheets_ws_Routes from './routes/sheets-ws.ts'
 import healthRoutes from './routes/health.ts';
 import { ws_server } from './webSocket_server.ts'
 import { customErrorHandler } from './utils/errorHandler.ts';
+import 'dotenv/config';
 
 console.log("geiler Backend Server starting...")
 

--- a/backend/src/interfaces/cognitoPayload.ts
+++ b/backend/src/interfaces/cognitoPayload.ts
@@ -1,0 +1,4 @@
+export interface CognitoPayload {
+    sub: string;
+    email?: string;
+};

--- a/backend/src/interfaces/cognitoPayload.ts
+++ b/backend/src/interfaces/cognitoPayload.ts
@@ -1,4 +1,5 @@
 export interface CognitoPayload {
-    sub: string;
+    sub: string; //equals userId
     email?: string;
+    username?: string;
 };

--- a/backend/src/routes/sheets-ws.ts
+++ b/backend/src/routes/sheets-ws.ts
@@ -5,6 +5,7 @@ import fastifyWebsocket from '@fastify/websocket';
 import { ws_server } from '../webSocket_server.ts'
 import { hasPermission } from '../utils/permissions.ts'
 import { WSSheetSchema } from '../schemas/sheet.ts';
+import { verifyUser } from '../utils/verifyUser.ts'
 
 // export as fastify plugin to index.ts
 export default async function (
@@ -24,8 +25,12 @@ export default async function (
     schema: {...WSSheetSchema},
     wsHandler: async (connection, request) => {
       const { id } = request.params as { id: string };
-      const userId = 'demo-user-id'; // TODO: Replace with real user ID from auth
-      //const token = extractToken(req.headers.authorization);
+
+      let payload = await verifyUser(request.headers.authorization);
+      if (!payload?.sub) {
+        throw fastify.httpErrors.unauthorized('Invalid Session') 
+      }
+      const user_id = payload.sub;
 
       const sheet = await db('sheets').where({ id }).first();
       if (!sheet) { 
@@ -38,12 +43,12 @@ export default async function (
       }
       // Permission check
       var allowed = false;
-      if (sheet.owner_id === userId) {
+      if (sheet.owner_id === user_id) {
         //immediate access if owner
         allowed = true;
       } else {
         //if not owner check for permissions (min: viewer)
-        allowed = await hasPermission(userId, id, 'viewer')
+        allowed = await hasPermission(user_id, id, 'viewer')
       }
       if (!allowed) {
         connection.socket.send(JSON.stringify({ message: 'No access', success: false }));
@@ -59,7 +64,7 @@ export default async function (
       });
       
       // Open Websocket Connection for Document (identified by database id)
-      ws_server.handleConnection(connection.socket, webRequest, { docName: id, userId: userId });
+      ws_server.handleConnection(connection.socket, webRequest, { docName: id, userId: user_id });
 
     },
     handler: async function myHandler(request, reply) {

--- a/backend/src/routes/sheets-ws.ts
+++ b/backend/src/routes/sheets-ws.ts
@@ -64,7 +64,7 @@ export default async function (
       });
       
       // Open Websocket Connection for Document (identified by database id)
-      ws_server.handleConnection(connection.socket, webRequest, { docName: id, userId: user_id });
+      ws_server.handleConnection(connection.socket, webRequest, { docName: id, userId: user_id, token: request.headers.authorization});
 
     },
     handler: async function myHandler(request, reply) {

--- a/backend/src/routes/sheets.ts
+++ b/backend/src/routes/sheets.ts
@@ -5,6 +5,8 @@ import { hasPermission } from '../utils/permissions.ts'
 import { isValidUUID } from '../utils/isValidUUID.ts'
 import { GETSheetSchema, POSTSheetSchema, DELETESheetSchema, SHARESheetSchema } from '../schemas/sheet.ts'
 import type { Sheet } from '../interfaces/sheet.ts'
+import { verifyJWT } from '../utils/verifyJWT.ts'
+
 
 // export as fastify plugin to index.ts
 export default async function (
@@ -20,7 +22,12 @@ export default async function (
     method: 'GET',
     schema: { ...GETSheetSchema },
     handler: async function myHandler(request, reply) {
-      const userId = 'demo-user-id'; // TODO: Replace with real user ID from auth
+      let payload = await verifyJWT(request.headers.authorization); //get Client-Side Stored JWT Token from Request
+      if (!payload?.sub) {
+        throw fastify.httpErrors.unauthorized('Invalid Session') //Invalid or no Token
+      }
+      const userId = payload.sub; //get UserId from Cognito Payload
+
       const userSheets = await db('sheets') // get user sheets
         .where({ owner_id: userId }) //(with owner check)
         .select('id', 'title', 'owner_id', 'created_at', 'updated_at'); // get only relevant data (no snapshot)

--- a/backend/src/routes/sheets.ts
+++ b/backend/src/routes/sheets.ts
@@ -26,13 +26,13 @@ export default async function (
       if (!payload?.sub) {
         throw fastify.httpErrors.unauthorized('Invalid Session') //Invalid or no Token
       }
-      const userId = payload.sub; //get UserId from Cognito Payload
+      const user_id = payload.sub; //get UserId from Cognito Payload
 
       const userSheets = await db('sheets') // get user sheets
-        .where({ owner_id: userId }) //(with owner check)
+        .where({ owner_id: user_id }) //(with owner check)
         .select('id', 'title', 'owner_id', 'created_at', 'updated_at'); // get only relevant data (no snapshot)
 
-      const permissions = await db('permissions').where({ user_id: userId});
+      const permissions = await db('permissions').where({ user_id: user_id});
       let sharedSheets: Array<Sheet> = [];
 
       //load shared sheets if any permissions for userid available
@@ -64,7 +64,11 @@ export default async function (
     handler: async function myHandler(request, reply) {
       const data = request.body as Sheet
 
-      const owner_id = 'demo-user-id' // request.user.id; Cognito/ JWT Token not implemented yet // TODO: Replace with real user ID from auth
+      let payload = await verifyJWT(request.headers.authorization); 
+      if (!payload?.sub) {
+        throw fastify.httpErrors.unauthorized('Invalid Session') 
+      }
+      const user_id = payload.sub; //get owner ID (current User) from Cognito Payload
 
       if (!data?.title || !data?.id) {
         throw fastify.httpErrors.badRequest(
@@ -74,7 +78,7 @@ export default async function (
       await db('sheets').insert({
         id: data.id,
         title: data.title,
-        owner_id: owner_id,
+        owner_id: user_id,
         yjs_snapshot: data.yjs_snapshot,
         updated_at: data.updated_at,
         created_at: data.created_at,
@@ -99,8 +103,12 @@ export default async function (
       if (!isValidUUID(id)) {
         throw fastify.httpErrors.badRequest('Invalid sheet ID');
       }
-      
-      const userId = 'demo-user-id'; // TODO: Replace with real user ID from auth
+
+      let payload = await verifyJWT(request.headers.authorization); 
+      if (!payload?.sub) {
+        throw fastify.httpErrors.unauthorized('Invalid Session') 
+      }
+      const user_id = payload.sub;
 
       const sheet = await db('sheets').where({ id }).first();
       if (!sheet) { 
@@ -108,7 +116,7 @@ export default async function (
           'Sheet not found.',
         )
        }
-      if (sheet.owner_id !== userId) { 
+      if (sheet.owner_id !== user_id) { 
         throw fastify.httpErrors.forbidden(
           'Sheet not deleted. Not authorized',
         )
@@ -128,7 +136,11 @@ export default async function (
     method: 'POST',
     schema: {...SHARESheetSchema},
     handler: async function myHandler(request, reply) {
-      const user_id = 'demo-user-id' // request.user.id; Cognito/ JWT Token not implemented yet // TODO: Replace with real user ID from auth
+      let payload = await verifyJWT(request.headers.authorization); 
+      if (!payload?.sub) {
+        throw fastify.httpErrors.unauthorized('Invalid Session') 
+      }
+      const user_id = payload.sub;
 
       const { id } = request.params as { id: string };
       

--- a/backend/src/routes/sheets.ts
+++ b/backend/src/routes/sheets.ts
@@ -142,15 +142,15 @@ export default async function (
       }
       const user_id = payload.sub;
 
-      const { id } = request.params as { id: string };
+      const { sheet_id } = request.params as { sheet_id: string };
       
-      if (!isValidUUID(id)) {
+      if (!isValidUUID(sheet_id)) {
         throw fastify.httpErrors.badRequest('Invalid sheet ID');
       }
 
       const { email, role } = request.body as { email: string; role: string };
       
-      const sheet = await db('sheets').where({ id }).first();
+      const sheet = await db('sheets').where({ sheet_id }).first();
       if (!sheet) {
         throw fastify.httpErrors.notFound('Sheet not found');
       }
@@ -161,17 +161,17 @@ export default async function (
       }
       //check if requesting user is owner or has editor role
       if(user_id !== sheet.owner_id ) {
-        if (!await hasPermission(user_id, id, 'editor')) {
+        if (!await hasPermission(user_id, sheet_id, 'editor')) {
           throw fastify.httpErrors.forbidden('Not authorized for sharing this sheet')
         }
       }
 
       // check if invited user already has Permission
-      const existingPermission = await db('permissions').where({ sheet_id: id, user_id: invited_user.id }).first();
+      const existingPermission = await db('permissions').where({ sheet_id: sheet_id, user_id: invited_user.id }).first();
       if(existingPermission) {
         if(existingPermission.role !== role) {
           //update role if already exists
-          await db('permissions').where({ sheet_id: id, user_id: invited_user.id}).update({role});
+          await db('permissions').where({ sheet_id: sheet_id, user_id: invited_user.id}).update({role});
           reply.send({
             message: `Permission for User ${email} updated to ${role}.`,
             success: true,
@@ -183,7 +183,7 @@ export default async function (
       }
       // Insert new permission if no permission exists
       await db('permissions').insert({
-        sheet_id: id,
+        sheet_id: sheet_id,
         user_id: invited_user.id,
         role: role
       })

--- a/backend/src/routes/sheets.ts
+++ b/backend/src/routes/sheets.ts
@@ -23,6 +23,7 @@ export default async function (
     schema: { ...GETSheetSchema },
     handler: async function myHandler(request, reply) {
       let payload = await verifyUser(request.headers.authorization); //get Client-Side Stored JWT Token from Request
+      
       if (!payload?.sub) {
         throw fastify.httpErrors.unauthorized('Invalid Session') //Invalid or no Token
       }

--- a/backend/src/routes/sheets.ts
+++ b/backend/src/routes/sheets.ts
@@ -5,7 +5,7 @@ import { hasPermission } from '../utils/permissions.ts'
 import { isValidUUID } from '../utils/isValidUUID.ts'
 import { GETSheetSchema, POSTSheetSchema, DELETESheetSchema, SHARESheetSchema } from '../schemas/sheet.ts'
 import type { Sheet } from '../interfaces/sheet.ts'
-import { verifyJWT } from '../utils/verifyJWT.ts'
+import { verifyUser } from '../utils/verifyUser.ts'
 
 
 // export as fastify plugin to index.ts
@@ -22,7 +22,7 @@ export default async function (
     method: 'GET',
     schema: { ...GETSheetSchema },
     handler: async function myHandler(request, reply) {
-      let payload = await verifyJWT(request.headers.authorization); //get Client-Side Stored JWT Token from Request
+      let payload = await verifyUser(request.headers.authorization); //get Client-Side Stored JWT Token from Request
       if (!payload?.sub) {
         throw fastify.httpErrors.unauthorized('Invalid Session') //Invalid or no Token
       }
@@ -64,7 +64,7 @@ export default async function (
     handler: async function myHandler(request, reply) {
       const data = request.body as Sheet
 
-      let payload = await verifyJWT(request.headers.authorization); 
+      let payload = await verifyUser(request.headers.authorization); 
       if (!payload?.sub) {
         throw fastify.httpErrors.unauthorized('Invalid Session') 
       }
@@ -98,19 +98,19 @@ export default async function (
     method: 'DELETE',
     schema: { ...DELETESheetSchema },
     handler: async function myHandler(request, reply) {
-      const { id } = request.params as { id: string };
+      const { id: sheet_id } = request.params as { id: string };
 
-      if (!isValidUUID(id)) {
+      if (!isValidUUID(sheet_id)) {
         throw fastify.httpErrors.badRequest('Invalid sheet ID');
       }
 
-      let payload = await verifyJWT(request.headers.authorization); 
+      let payload = await verifyUser(request.headers.authorization); 
       if (!payload?.sub) {
         throw fastify.httpErrors.unauthorized('Invalid Session') 
       }
       const user_id = payload.sub;
 
-      const sheet = await db('sheets').where({ id }).first();
+      const sheet = await db('sheets').where({ id: sheet_id }).first();
       if (!sheet) { 
         throw fastify.httpErrors.notFound(
           'Sheet not found.',
@@ -121,7 +121,7 @@ export default async function (
           'Sheet not deleted. Not authorized',
         )
        }
-      await db('sheets').where({ id }).del(); // delete sheet
+      await db('sheets').where({ id: sheet_id }).del(); // delete sheet
       reply.send({
         message: 'Sheet deleted successfully',
         success: true,
@@ -136,13 +136,13 @@ export default async function (
     method: 'POST',
     schema: {...SHARESheetSchema},
     handler: async function myHandler(request, reply) {
-      let payload = await verifyJWT(request.headers.authorization); 
+      let payload = await verifyUser(request.headers.authorization); 
       if (!payload?.sub) {
         throw fastify.httpErrors.unauthorized('Invalid Session') 
       }
       const user_id = payload.sub;
 
-      const { sheet_id } = request.params as { sheet_id: string };
+      const { id: sheet_id } = request.params as { id: string };
       
       if (!isValidUUID(sheet_id)) {
         throw fastify.httpErrors.badRequest('Invalid sheet ID');
@@ -150,7 +150,7 @@ export default async function (
 
       const { email, role } = request.body as { email: string; role: string };
       
-      const sheet = await db('sheets').where({ sheet_id }).first();
+      const sheet = await db('sheets').where({ id: sheet_id }).first();
       if (!sheet) {
         throw fastify.httpErrors.notFound('Sheet not found');
       }

--- a/backend/src/utils/verifyJWT.ts
+++ b/backend/src/utils/verifyJWT.ts
@@ -1,0 +1,29 @@
+import { CognitoJwtVerifier } from "aws-jwt-verify";
+import type { JwtPayload } from "aws-jwt-verify/jwt-model";
+import type { CognitoPayload } from "../interfaces/cognitoPayload.ts";
+
+const verifier = CognitoJwtVerifier.create({
+  userPoolId: process.env.COGNITO_USER_POOL_ID!,
+  tokenUse: 'access',
+  clientId: process.env.COGNITO_CLIENT_ID!,
+});
+
+export async function verifyJWT(authHeader?: string): Promise<CognitoPayload | null> {
+    const token = authHeader?.startsWith('Bearer ')
+        ? authHeader.slice(7) //get pure Token String
+        : undefined;
+
+    console.log("Extracted Token:", token) //DEV!
+        
+    if(!token) {
+        return null; //auth not possible
+    }
+    try{
+        const payload = await verifier.verify(token) as CognitoPayload
+        console.log("Token is valid. Payload:", payload); //returns Cognito payload with userid
+        return payload;
+    } catch {
+        console.log("Token not valid!");
+        return null;
+    }
+}

--- a/backend/src/utils/verifyUser.ts
+++ b/backend/src/utils/verifyUser.ts
@@ -1,6 +1,6 @@
 import { CognitoJwtVerifier } from "aws-jwt-verify";
-import type { JwtPayload } from "aws-jwt-verify/jwt-model";
 import type { CognitoPayload } from "../interfaces/cognitoPayload.ts";
+import db from '../db.ts'
 
 const verifier = CognitoJwtVerifier.create({
   userPoolId: process.env.COGNITO_USER_POOL_ID!,
@@ -8,7 +8,7 @@ const verifier = CognitoJwtVerifier.create({
   clientId: process.env.COGNITO_CLIENT_ID!,
 });
 
-export async function verifyJWT(authHeader?: string): Promise<CognitoPayload | null> {
+export async function verifyUser(authHeader?: string): Promise<CognitoPayload | null> {
     const token = authHeader?.startsWith('Bearer ')
         ? authHeader.slice(7) //get pure Token String
         : undefined;
@@ -18,9 +18,19 @@ export async function verifyJWT(authHeader?: string): Promise<CognitoPayload | n
     if(!token) {
         return null; //auth not possible
     }
+
     try{
         const payload = await verifier.verify(token) as CognitoPayload
         console.log("Token is valid. Payload:", payload); //returns Cognito payload with userid
+
+        if(!await db('users').where({ id: payload.sub })) {
+            //first authentication of this user: add user to DB user table
+            await db('sheets').insert({
+            id: payload.sub,
+            email: // TODO: insert users into user table 
+      })
+        } 
+
         return payload;
     } catch {
         console.log("Token not valid!");

--- a/backend/src/utils/verifyUser.ts
+++ b/backend/src/utils/verifyUser.ts
@@ -7,6 +7,7 @@ const verifier = CognitoJwtVerifier.create({
   tokenUse: 'access',
   clientId: process.env.COGNITO_CLIENT_ID!,
 });
+const cognitoDomain = process.env.COGNITO_DOMAIN;
 
 export async function verifyUser(authHeader?: string): Promise<CognitoPayload | null> {
     const token = authHeader?.startsWith('Bearer ')
@@ -24,10 +25,16 @@ export async function verifyUser(authHeader?: string): Promise<CognitoPayload | 
         console.log("Token is valid. Payload:", payload); //returns Cognito payload with userid
 
         if(!await db('users').where({ id: payload.sub })) {
-            //first authentication of this user: add user to DB user table
-            await db('sheets').insert({
+            //first authentication of this user: add user to DB user table with fetched email adress
+
+            let email = payload.email
+            if(!email) {
+                let additional_userdata = await fetch('${cognitoDomain}/oauth2/userInfo' )
+            }
+
+            await db('users').insert({
             id: payload.sub,
-            email: // TODO: insert users into user table 
+            email: email // TODO: insert users into user table 
       })
         } 
 

--- a/backend/src/utils/verifyUser.ts
+++ b/backend/src/utils/verifyUser.ts
@@ -15,7 +15,12 @@ export async function verifyUser(authHeader?: string): Promise<CognitoPayload | 
         : undefined;
 
     console.log("Extracted Token:", token) //DEV!
-        
+    
+    if (process.env.NODE_ENV === 'test' && process.env.AUTH_BYPASS === 'true') {
+        //Bypass if local Test Env  
+        return { sub: 'demo-user-id', email: 'demo@example.com'};
+    }
+
     if(!token) {
         return null; //auth not possible
     }
@@ -24,23 +29,29 @@ export async function verifyUser(authHeader?: string): Promise<CognitoPayload | 
         const payload = await verifier.verify(token) as CognitoPayload
         console.log("Token is valid. Payload:", payload); //returns Cognito payload with userid
 
-        if(!await db('users').where({ id: payload.sub })) {
+        const user_exists = await db('users').where({ id: payload.sub }).first();
+        if(!user_exists) {
             //first authentication of this user: add user to DB user table with fetched email adress
-
             let email = payload.email
             if(!email) {
-                let additional_userdata = await fetch('${cognitoDomain}/oauth2/userInfo' )
+                let response = await fetch(`${cognitoDomain}/oauth2/userInfo`, {
+                    method: 'GET',
+                    headers: {
+                        "Authorization": `Bearer ${token}`,
+                    }
+                } );
+                let additional_userdata = await response.json();
+                email = additional_userdata.email
             }
-
             await db('users').insert({
             id: payload.sub,
-            email: email // TODO: insert users into user table 
-      })
+            email: email
+            });
         } 
 
         return payload;
-    } catch {
-        console.log("Token not valid!");
+    } catch(err) {
+        console.error("Token verification failed!: ", err);
         return null;
     }
 }

--- a/backend/src/webSocket_server.ts
+++ b/backend/src/webSocket_server.ts
@@ -25,14 +25,14 @@ export const ws_server = new Hocuspocus({
         //fetch users permission role for sheet
         const permission = await db('permissions').where({ user_id: data.context.userId, sheet_id: data.documentName}).first();
         if (sheet.owner_id === data.context.userId) {
-            data.context.role === 'owner' //owner check
+            data.context.role = 'owner' //owner check
         } else {
             data.context.role = permission ? permission.role : null; //set permission role otherwise set null
             }
     },
     async onChange(data) {
         // Only allow editor and owner to make changes to document
-        if (data.context.role !== 'editor' || 'owner') {
+        if (data.context.role !== 'editor' && data.context.role !== 'owner') {
             return; //Changes are being ignored for viewer role
         }
     },

--- a/backend/src/webSocket_server.ts
+++ b/backend/src/webSocket_server.ts
@@ -1,14 +1,26 @@
 import { Hocuspocus } from '@hocuspocus/server'
 import * as Y from 'yjs';
 import db from './db.ts'
+import { verifyUser } from './utils/verifyUser.ts'
 
 // initialize Hocuspocus Websocket Server
 export const ws_server = new Hocuspocus({
     //TODO: add hooks for authentication/persistence here https://tiptap.dev/docs/hocuspocus/server/hooks
-    // async onAuthenticate({ token }) {
+    async onAuthenticate({ token }) {
     //validate tokens before connection established
-    //   return { userId: '123', permissions: ['read', 'write'] }
-    // },
+    const payload = await verifyUser(token)
+
+    if (!payload?.sub) {
+        throw new Error('Unauthorized: Invalid token or user check failed') 
+      }
+
+    return {
+        user: { 
+            user_id: payload.sub, 
+            email: payload.email
+        },
+      }
+    },
     async onConnect(data) {
     //Logging
     console.log(`New connection to sheet: ${data.documentName}`)

--- a/infra/hello-cdk/bin/hello-cdk.ts
+++ b/infra/hello-cdk/bin/hello-cdk.ts
@@ -63,5 +63,10 @@ new EcrStack(app, 'EcrStack', {
 
 // ECS Express Mode Hello World stack (replaces deprecated App Runner)
 new EcsExpressStack(app, 'EcsExpressStack', {
+  environment,
+  cognitoUserPoolId: frontendStack.userPoolId,
+  cognitoClientId: frontendStack.userPoolClientId,
+  cognitoDomain: frontendStack.cognitoDomain,
+}, {
   env,
 });

--- a/infra/hello-cdk/bin/hello-cdk.ts
+++ b/infra/hello-cdk/bin/hello-cdk.ts
@@ -67,6 +67,7 @@ new EcsExpressStack(app, 'EcsExpressStack', {
   cognitoUserPoolId: frontendStack.userPoolId,
   cognitoClientId: frontendStack.userPoolClientId,
   cognitoDomain: frontendStack.cognitoDomain,
+  database: backendStack.postgresDB,
 }, {
   env,
 });

--- a/infra/hello-cdk/bin/hello-cdk.ts
+++ b/infra/hello-cdk/bin/hello-cdk.ts
@@ -68,6 +68,7 @@ new EcsExpressStack(app, 'EcsExpressStack', {
   cognitoUserPoolId: frontendStack.userPoolId,
   cognitoClientId: frontendStack.userPoolClientId,
   cognitoDomain: frontendStack.cognitoDomain,
+  // Config:
   database: backendStack.postgresDB,
   vpc: backendStack.vpc,
   backendSecurityGroup: backendStack.backendSG,

--- a/infra/hello-cdk/bin/hello-cdk.ts
+++ b/infra/hello-cdk/bin/hello-cdk.ts
@@ -64,10 +64,13 @@ new EcrStack(app, 'EcrStack', {
 // ECS Express Mode Hello World stack (replaces deprecated App Runner)
 new EcsExpressStack(app, 'EcsExpressStack', {
   environment,
+  //Cross Stack References:
   cognitoUserPoolId: frontendStack.userPoolId,
   cognitoClientId: frontendStack.userPoolClientId,
   cognitoDomain: frontendStack.cognitoDomain,
   database: backendStack.postgresDB,
+  vpc: backendStack.vpc,
+  backendSecurityGroup: backendStack.backendSG,
 }, {
   env,
 });

--- a/infra/hello-cdk/lib/backend-stack.ts
+++ b/infra/hello-cdk/lib/backend-stack.ts
@@ -11,6 +11,7 @@ export interface BackendStackConfig {
  
  export class BackendStack extends Stack {
   
+  public postgresDB: DatabaseInstance;
   
   constructor(scope: Construct, id: string, config: BackendStackConfig, props?: StackProps) {
      super(scope, id, props);
@@ -36,7 +37,7 @@ export interface BackendStackConfig {
       
 
       //RDS PostgreSQL Instance (db.t3.micro)
-      new DatabaseInstance(this, 'PostgresDB', { 
+      const postgresDB = new DatabaseInstance(this, 'PostgresDB', { 
         engine: DatabaseInstanceEngine.postgres({version: PostgresEngineVersion.VER_18_2}),
         instanceType: InstanceType.of(InstanceClass.T3, InstanceSize.MICRO),
         vpc,
@@ -47,7 +48,6 @@ export interface BackendStackConfig {
         backupRetention: Duration.days(0), //backups stored for 0 days
         removalPolicy: config.environment === 'dev' ? RemovalPolicy.DESTROY : RemovalPolicy.RETAIN, //automatically delete db when stack is removed for dev
       });
-
       
    }
  }

--- a/infra/hello-cdk/lib/backend-stack.ts
+++ b/infra/hello-cdk/lib/backend-stack.ts
@@ -11,36 +11,38 @@ export interface BackendStackConfig {
  
  export class BackendStack extends Stack {
   
-  public postgresDB: DatabaseInstance;
-  
+  public readonly vpc: Vpc;
+  public readonly backendSG: SecurityGroup;
+  public readonly postgresDB: DatabaseInstance;
+
   constructor(scope: Construct, id: string, config: BackendStackConfig, props?: StackProps) {
      super(scope, id, props);
 
      
       //Backend VPC
-      const vpc = new Vpc(this, 'BackendVpc', { maxAzs: 2 }); 
+      this.vpc = new Vpc(this, 'BackendVpc', { maxAzs: 2 }); 
       //AWS doesn't allow RDS instances outside of VPCs due to access control
 
       // Security Groups for backend (allow Outbound)
-      const backendSG = new SecurityGroup(this, 'BackendSG', {
-        vpc,
+      this.backendSG = new SecurityGroup(this, 'BackendSG', {
+        vpc: this.vpc,
         allowAllOutbound: true,
       });
       // separate for RDS instance (deny Outbound)
       const dbSG = new SecurityGroup(this, 'DbSG', {
-        vpc,
+        vpc: this.vpc,
         allowAllOutbound: false,
       });
       
       // Allow backend to connect to db on PostgreSQL port (5432)
-      dbSG.addIngressRule(backendSG, Port.tcp(5432), 'Allow backend to access DB');
+      dbSG.addIngressRule(this.backendSG, Port.tcp(5432), 'Allow backend to access DB');
       
 
       //RDS PostgreSQL Instance (db.t3.micro)
       const postgresDB = new DatabaseInstance(this, 'PostgresDB', { 
         engine: DatabaseInstanceEngine.postgres({version: PostgresEngineVersion.VER_18_2}),
         instanceType: InstanceType.of(InstanceClass.T3, InstanceSize.MICRO),
-        vpc,
+        vpc: this.vpc,
         securityGroups: [dbSG],
         allocatedStorage: 20, //disable autoscaling to stay in free tier scope
        // storageType: StorageType.GP2,

--- a/infra/hello-cdk/lib/backend-stack.ts
+++ b/infra/hello-cdk/lib/backend-stack.ts
@@ -39,7 +39,7 @@ export interface BackendStackConfig {
       
 
       //RDS PostgreSQL Instance (db.t3.micro)
-      const postgresDB = new DatabaseInstance(this, 'PostgresDB', { 
+      this.postgresDB = new DatabaseInstance(this, 'PostgresDB', { 
         engine: DatabaseInstanceEngine.postgres({version: PostgresEngineVersion.VER_18_2}),
         instanceType: InstanceType.of(InstanceClass.T3, InstanceSize.MICRO),
         vpc: this.vpc,

--- a/infra/hello-cdk/lib/ecs-express-stack.ts
+++ b/infra/hello-cdk/lib/ecs-express-stack.ts
@@ -3,6 +3,7 @@ import { Construct } from 'constructs';
 import { CfnExpressGatewayService } from 'aws-cdk-lib/aws-ecs';
 import { Role, ServicePrincipal, ManagedPolicy } from 'aws-cdk-lib/aws-iam';
 import { DatabaseInstance } from 'aws-cdk-lib/aws-rds';
+import { Vpc, ISecurityGroup, ISubnet } from 'aws-cdk-lib/aws-ec2';
 
 interface EcsExpressStackConfig {
   environment: "dev" | "prod";
@@ -10,6 +11,8 @@ interface EcsExpressStackConfig {
   cognitoClientId: string;
   cognitoDomain: string;
   database: DatabaseInstance;
+  vpc: Vpc;
+  backendSecurityGroup: ISecurityGroup;
 }
 
 export class EcsExpressStack extends Stack {
@@ -59,6 +62,10 @@ export class EcsExpressStack extends Stack {
           { name: 'COGNITO_DOMAIN', value: config.cognitoDomain },
           { name: 'DATABASE_URL', value: databaseUrl }
         ],
+      },
+      networkConfiguration: {
+        subnets: config.vpc.privateSubnets.map((subnet: ISubnet) => subnet.subnetId),
+        securityGroups: [config.backendSecurityGroup.securityGroupId],
       },
       cpu: '256',
       memory: '512',

--- a/infra/hello-cdk/lib/ecs-express-stack.ts
+++ b/infra/hello-cdk/lib/ecs-express-stack.ts
@@ -2,12 +2,14 @@ import { Stack, StackProps, CfnOutput } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { CfnExpressGatewayService } from 'aws-cdk-lib/aws-ecs';
 import { Role, ServicePrincipal, ManagedPolicy } from 'aws-cdk-lib/aws-iam';
+import { DatabaseInstance } from 'aws-cdk-lib/aws-rds';
 
 interface EcsExpressStackConfig {
   environment: "dev" | "prod";
   cognitoUserPoolId: string;
   cognitoClientId: string;
   cognitoDomain: string;
+  database: DatabaseInstance;
 }
 
 export class EcsExpressStack extends Stack {
@@ -34,6 +36,15 @@ export class EcsExpressStack extends Stack {
       ],
     });
 
+    // DB Setup
+    const dbHost = config.database.dbInstanceEndpointAddress;
+    const dbPort = config.database.dbInstanceEndpointPort;
+    const dbName = 'cloudsheet';
+    const dbUser = config.database.secret?.secretValueFromJson('username').unsafeUnwrap() ?? 'cloudsheet'; // Unpack database credentials from AWS Secrets Manager
+    const dbPass = config.database.secret?.secretValueFromJson('password').unsafeUnwrap() ?? '';
+
+    const databaseUrl = `postgresql://${dbUser}:${dbPass}@${dbHost}:${dbPort}/${dbName}`;
+
     // ECS Express Mode service — replaces App Runner
     const service = new CfnExpressGatewayService(this, 'ExpressService', {
       serviceName: 'cloudsheets-hello-world',
@@ -46,6 +57,7 @@ export class EcsExpressStack extends Stack {
           { name: 'COGNITO_USER_POOL_ID', value: config.cognitoUserPoolId },
           { name: 'COGNITO_CLIENT_ID', value: config.cognitoClientId },
           { name: 'COGNITO_DOMAIN', value: config.cognitoDomain },
+          { name: 'DATABASE_URL', value: databaseUrl }
         ],
       },
       cpu: '256',

--- a/infra/hello-cdk/lib/ecs-express-stack.ts
+++ b/infra/hello-cdk/lib/ecs-express-stack.ts
@@ -3,10 +3,18 @@ import { Construct } from 'constructs';
 import { CfnExpressGatewayService } from 'aws-cdk-lib/aws-ecs';
 import { Role, ServicePrincipal, ManagedPolicy } from 'aws-cdk-lib/aws-iam';
 
-export class EcsExpressStack extends Stack {
-  constructor(scope: Construct, id: string, props?: StackProps) {
-    super(scope, id, props);
+interface EcsExpressStackConfig {
+  environment: "dev" | "prod";
+  cognitoUserPoolId: string;
+  cognitoClientId: string;
+  cognitoDomain: string;
+}
 
+export class EcsExpressStack extends Stack {
+
+  constructor(scope: Construct, id: string, config: EcsExpressStackConfig, props?: StackProps) {
+    super(scope, id, props);
+    
     // IAM Role: allows ECS to pull images and write logs
     const executionRole = new Role(this, 'EcsExpressExecutionRole', {
       assumedBy: new ServicePrincipal('ecs-tasks.amazonaws.com'),
@@ -34,6 +42,11 @@ export class EcsExpressStack extends Stack {
       primaryContainer: {
         image: 'public.ecr.aws/docker/library/nginx:latest',
         containerPort: 80,
+        environment: [
+          { name: 'COGNITO_USER_POOL_ID', value: config.cognitoUserPoolId },
+          { name: 'COGNITO_CLIENT_ID', value: config.cognitoClientId },
+          { name: 'COGNITO_DOMAIN', value: config.cognitoDomain },
+        ],
       },
       cpu: '256',
       memory: '512',

--- a/infra/hello-cdk/lib/frontend-stack.ts
+++ b/infra/hello-cdk/lib/frontend-stack.ts
@@ -22,6 +22,10 @@ interface CognitoConfig {
 }*/
 
 export class FrontendStack extends Stack {
+  public readonly userPoolId: string;
+  public readonly userPoolClientId: string;
+  public readonly cognitoDomain: string;
+
   constructor(scope: Construct, id: string, config: FrontendStackConfig, props?: StackProps) {
     super(scope, id, props);
       
@@ -123,15 +127,19 @@ export class FrontendStack extends Stack {
         },
       });
 
+      this.userPoolId = userPool.userPoolId;
+      this.userPoolClientId = userPoolClient.userPoolClientId;
+      this.cognitoDomain = providerDomain.baseUrl();
+
       new CfnOutput(this, 'UserPoolId', {
-        value: userPool.userPoolId
+        value: this.userPoolId
       });
       
       new CfnOutput(this, 'UserPoolClientId', {
-        value: userPoolClient.userPoolClientId,
+        value: this.userPoolClientId,
       });
       new CfnOutput(this, 'CognitoDomainUrl', {
-        value: providerDomain.baseUrl(),
+        value: this.cognitoDomain
       });
 
       
@@ -139,11 +147,11 @@ export class FrontendStack extends Stack {
   sources: [
     s3deploy.Source.asset(path.join(__dirname, '../../../frontend/dist')),
     s3deploy.Source.jsonData('config.json', {  // ← direkt hier!
-      authority: `https://cognito-idp.${this.region}.amazonaws.com/${userPool.userPoolId}`,
-      clientId: userPoolClient.userPoolClientId,
+      authority: `https://cognito-idp.${this.region}.amazonaws.com/${this.userPoolId}`,
+      clientId: this.userPoolClientId,
       callbackUrl: baseUrl,
       logoutUrl: baseUrl,
-      cognitoDomain: providerDomain.baseUrl(),
+      cognitoDomain: this.cognitoDomain,
     }),
   ],
   destinationBucket: bucket,

--- a/infra/hello-cdk/test/ecs-express.test.ts
+++ b/infra/hello-cdk/test/ecs-express.test.ts
@@ -7,7 +7,7 @@ describe('EcsExpressStack', () => {
 
   beforeAll(() => {
     const app = new cdk.App();
-    const stack = new EcsExpressStack(app, 'TestEcsExpressStack');
+    const stack = new EcsExpressStack(app, 'TestEcsExpressStack', { environment: 'dev', cognitoUserPoolId: 'test-pool', cognitoClientId: 'test-client', cognitoDomain: 'https://example.com'});
     template = Template.fromStack(stack);
   });
 

--- a/infra/hello-cdk/test/ecs-express.test.ts
+++ b/infra/hello-cdk/test/ecs-express.test.ts
@@ -1,13 +1,26 @@
 import * as cdk from 'aws-cdk-lib/core';
 import { Template } from 'aws-cdk-lib/assertions';
 import { EcsExpressStack } from '../lib/ecs-express-stack';
+import { BackendStack } from '../lib/backend-stack';
 
 describe('EcsExpressStack', () => {
   let template: Template;
 
   beforeAll(() => {
     const app = new cdk.App();
-    const stack = new EcsExpressStack(app, 'TestEcsExpressStack', { environment: 'dev', cognitoUserPoolId: 'test-pool', cognitoClientId: 'test-client', cognitoDomain: 'https://example.com'});
+
+    const backendStack = new BackendStack(app, 'TestBackendStack', {
+      environment: 'dev',
+    })
+    const stack = new EcsExpressStack(app, 'TestEcsExpressStack', {
+       environment: 'dev', 
+       cognitoUserPoolId: 'test-pool', 
+       cognitoClientId: 'test-client', 
+       cognitoDomain: 'https://example.com', 
+       vpc: backendStack.vpc, 
+       backendSecurityGroup: backendStack.backendSG,
+       database: backendStack.postgresDB
+      });
     template = Template.fromStack(stack);
   });
 


### PR DESCRIPTION
## What does this PR do?
 - add verifyUser.ts Util to authenticate requests with Cognito Access Token and return Token Payload
 - implement User auhtentication in every endpoint (including onAuthenticate Hook for Websocket)
 
 - inject necessary variables for Cognito Authentication into .env File
 - added second .env File with Variables for bypassing Cognito Authentication when testing locally
 - added new scripts to start in Test mode (with auth bypass activated)
 
- initialize Postgres DB with network configuration and connect to backend
- update ecs-express.test.ts to include the necessary configuration for initialization of Ecs Express Stack (Database, Vpc, Security Groups)
- add backendstack to ecs tests
 
Closes #38
 
## How to test?
 - navigate `cd /backend` and use `npm run dev:test` and then `npm test` or use `npm run test:all`
 
## Checklist
 
- [x] Tested locally
- [x] No secrets in code
- [ ] CDK synth passes (if infra change)
